### PR TITLE
Move versions to own build file, bump kotlinx version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,14 @@ repositories {
     mavenCentral()
 }
 
+apply from: "./versions.gradle"
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.0'
-    implementation "io.reactivex.rxjava2:rxjava:2.2.7"
-    implementation "io.reactivex.rxjava3:rxjava:3.0.0-RC2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinx}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${versions.kotlinx}"
+    implementation "io.reactivex.rxjava2:rxjava:${versions.rxJava2}"
+    implementation "io.reactivex.rxjava3:rxjava:${versions.rxJava3}"
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,0 +1,5 @@
+ext.versions = [
+        "kotlinx": "1.3.2",
+        "rxJava2": "2.2.7",
+        "rxJava3": "3.0.0-RC2"
+]


### PR DESCRIPTION
Pulling the versions to their own file will make future updates even easier.

Also, bump kotlinx library version while I was in the area.