### PR TITLE
Update Interop samples to use top level functions

### DIFF
--- a/src/main/kotlin/interop/completable/CompletableInterop.kt
+++ b/src/main/kotlin/interop/completable/CompletableInterop.kt
@@ -9,7 +9,7 @@ import kotlin.coroutines.CoroutineContext
 class CompletableInterop(
     override val coroutineContext: CoroutineContext = Dispatchers.Default
 ): CoroutineScope {
-    fun doWork() = CoroutineScope(coroutineContext).rxCompletable {
+    fun doWork() = rxCompletable {
         delay(1000)
         println("Hello from the coroutine!")
     }

--- a/src/main/kotlin/interop/flowable/FlowableInterop.kt
+++ b/src/main/kotlin/interop/flowable/FlowableInterop.kt
@@ -2,14 +2,13 @@ package interop.flowable
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.rx2.rxFlowable
 import kotlin.coroutines.CoroutineContext
 
 class FlowableInterop(
     override val coroutineContext: CoroutineContext = Dispatchers.Default
 ): CoroutineScope {
-    fun getFlowable() = CoroutineScope(coroutineContext).rxFlowable {
+    fun getFlowable() = rxFlowable {
         (1..10).map {
             send(it)
         }

--- a/src/main/kotlin/interop/maybe/MaybeInterop.kt
+++ b/src/main/kotlin/interop/maybe/MaybeInterop.kt
@@ -9,7 +9,7 @@ import kotlin.random.Random
 class MaybeInterop(
     override val coroutineContext: CoroutineContext = Dispatchers.Default
 ): CoroutineScope {
-    fun doWorkMaybe() = CoroutineScope(coroutineContext).rxMaybe {
+    fun doWorkMaybe() = rxMaybe {
         return@rxMaybe if (Random.Default.nextBoolean()) "A value from the function" else null
     }
 }

--- a/src/main/kotlin/interop/observable/ObservableInterop.kt
+++ b/src/main/kotlin/interop/observable/ObservableInterop.kt
@@ -9,7 +9,7 @@ import kotlin.coroutines.CoroutineContext
 class ObservableInterop(
     override val coroutineContext: CoroutineContext = Dispatchers.Default
 ): CoroutineScope {
-    fun getStream() = CoroutineScope(coroutineContext).rxObservable {
+    fun getStream() = rxObservable {
         (1..10).map {
             delay(100)
             send(it)

--- a/src/main/kotlin/interop/single/SingleInterop.kt
+++ b/src/main/kotlin/interop/single/SingleInterop.kt
@@ -1,13 +1,15 @@
 package interop.single
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.rx2.rxSingle
 import kotlin.coroutines.CoroutineContext
 
 class SingleInterop(
     override val coroutineContext: CoroutineContext = Dispatchers.Default
 ): CoroutineScope {
-    fun doWork() = CoroutineScope(coroutineContext).rxSingle {
+    fun doWork() = rxSingle {
         delay(1000)
         return@rxSingle "Hello!"
     }


### PR DESCRIPTION
The latest API updates allow for the use of the Interop functions
without specifying the scope. In this case the coroutines underlying the
execution will be instantiated under the parent's scope. In the case of
these samples, that scope is the scope that is created by the class
implementing CoroutineScope.

*Note: this PR is into the branch defined by #6. I kept them separate since they address fundamentally different issues.*